### PR TITLE
Remaining Spawn Restriction | Mappings update | Config option to block multiple boss spawning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,24 @@ minecraft {
 }
 
 repositories {
+    maven {
+        name = "Progwml6 maven"
+        url = "http://dvs1.progwml6.com/files/maven"
+    }
+
+    maven {
+        url "https://www.cursemaven.com"
+    }
 }
 
 dependencies {
+    //Compile against the JEI API but do not include it at runtime
+    compileOnly 'mezz.jei:jei_1.12.2:4.15.+:api'
 
+    //At runtime, use the full JEI jar
+    runtimeOnly 'mezz.jei:jei_1.12.2:4.15.+'
+
+    implementation "curse.maven:sereneseasons-291874:2799213"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mod_version=1.2.1.0
-forge_snapshot=20171003
+forge_snapshot=20180814
 forge_version=1.12.2-14.23.5.2847

--- a/sample_fights/all_the_restrictions.json
+++ b/sample_fights/all_the_restrictions.json
@@ -56,7 +56,11 @@
     "biomes": [
       "minecraft:plains"
     ],
-    "groundRadius": 12
+    "groundRadius": 12,
+    "sereneSeasons": {
+      "season": "summer",
+      "subSeason": "mid"
+    }
   },
   "recipe": {
     "type": "minecraft:crafting_shaped",

--- a/sample_fights/skeleton.json
+++ b/sample_fights/skeleton.json
@@ -32,6 +32,11 @@
     ],
     "commandToRunAtSpawn": "/weather rain"
   },
+  "restrictions": {
+    "sereneSeasons": {
+      "season": "AUTUMN"
+    }
+  },
   "recipe": {
     "type": "minecraft:crafting_shaped",
     "group": "Summon",

--- a/src/main/java/com/wuest/from_the_depths/ModRegistry.java
+++ b/src/main/java/com/wuest/from_the_depths/ModRegistry.java
@@ -6,6 +6,7 @@ import com.wuest.from_the_depths.blocks.BlockAltarOfSpawning;
 import com.wuest.from_the_depths.config.ResourceLocationTypeAdapter;
 import com.wuest.from_the_depths.entityinfo.SpawnInfo;
 import com.wuest.from_the_depths.entityinfo.restrictions.RestrictionBundle;
+import com.wuest.from_the_depths.integration.SSHelper;
 import com.wuest.from_the_depths.items.ItemTotemOfSpawning;
 import com.wuest.from_the_depths.proxy.messages.ConfigSyncMessage;
 import com.wuest.from_the_depths.proxy.messages.handlers.ConfigSyncHandler;
@@ -248,9 +249,15 @@ public class ModRegistry {
 						if (JsonUtils.hasField(json, "restrictions")) {
 							JsonObject restrictions = JsonUtils.getJsonObject(json, "restrictions");
 
+							String key = JsonUtils.getString(json, "key");
+
+							if (SSHelper.isSereneSeasonLoaded.getAsBoolean() && restrictions.has("sereneSeasons")) {
+								JsonObject seasonObj = JsonUtils.getJsonObject(restrictions, "sereneSeasons");
+								SSHelper.addSeasonRestriction(key, seasonObj);
+							}
+
 							RestrictionBundle bundle = gson.fromJson(restrictions, RestrictionBundle.class);
 
-							String key = JsonUtils.getString(json, "key");
 							//FromTheDepths.logger.info("Registering Spawn info restrictions for " + key + ". Restrictions: " + bundle);
 							spawnRestrictions.put(key, bundle);
 						}

--- a/src/main/java/com/wuest/from_the_depths/ModRegistry.java
+++ b/src/main/java/com/wuest/from_the_depths/ModRegistry.java
@@ -402,7 +402,7 @@ public class ModRegistry {
 	public static void setItemName(Item item, String itemName) {
 		if (itemName != null) {
 			item.setRegistryName("from_the_depths:" + itemName);
-			item.setUnlocalizedName(item.getRegistryName().toString());
+			item.setTranslationKey(item.getRegistryName().toString());
 		}
 	}
 
@@ -415,7 +415,7 @@ public class ModRegistry {
 	 */
 	public static void setBlockName(Block block, String blockName) {
 		block.setRegistryName(blockName);
-		block.setUnlocalizedName(block.getRegistryName().toString());
+		block.setTranslationKey(block.getRegistryName().toString());
 	}
 
 	/**

--- a/src/main/java/com/wuest/from_the_depths/blocks/BlockAltarOfSpawning.java
+++ b/src/main/java/com/wuest/from_the_depths/blocks/BlockAltarOfSpawning.java
@@ -1,12 +1,9 @@
 package com.wuest.from_the_depths.blocks;
 
-import java.util.Random;
-
 import com.wuest.from_the_depths.FromTheDepths;
 import com.wuest.from_the_depths.ModRegistry;
 import com.wuest.from_the_depths.base.TileBlockBase;
 import com.wuest.from_the_depths.tileentity.TileEntityAltarOfSpawning;
-
 import net.minecraft.block.BlockHorizontal;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.MapColor;
@@ -18,17 +15,15 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.BlockRenderLayer;
-import net.minecraft.util.EnumBlockRenderType;
-import net.minecraft.util.EnumFacing;
-import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.Mirror;
-import net.minecraft.util.Rotation;
+import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import javax.annotation.Nonnull;
+import java.util.Random;
 
 /**
  * 
@@ -103,14 +98,17 @@ public class BlockAltarOfSpawning extends TileBlockBase<TileEntityAltarOfSpawnin
     return false;
   }
 
-  @SideOnly(Side.CLIENT)
+  @Nonnull
   @Override
-  public BlockRenderLayer getBlockLayer() {
+  public BlockRenderLayer getRenderLayer()
+  {
     return BlockRenderLayer.CUTOUT;
   }
 
+  @SuppressWarnings("deprecation")
+  @Nonnull
   @Override
-  public EnumBlockRenderType getRenderType(IBlockState state) {
+  public EnumBlockRenderType getRenderType(@Nonnull IBlockState state) {
     return EnumBlockRenderType.MODEL;
   }
 
@@ -178,9 +176,11 @@ public class BlockAltarOfSpawning extends TileBlockBase<TileEntityAltarOfSpawnin
   /**
    * Convert the given metadata into a BlockState for this Block
    */
+  @SuppressWarnings("deprecation")
+  @Nonnull
   @Override
   public IBlockState getStateFromMeta(int meta) {
-    EnumFacing enumfacing = EnumFacing.getFront(meta);
+    EnumFacing enumfacing = EnumFacing.byIndex(meta);
 
     if (enumfacing.getAxis() == EnumFacing.Axis.Y) {
       enumfacing = EnumFacing.NORTH;

--- a/src/main/java/com/wuest/from_the_depths/config/ConfigTileEntityAltarOfSpawning.java
+++ b/src/main/java/com/wuest/from_the_depths/config/ConfigTileEntityAltarOfSpawning.java
@@ -1,16 +1,15 @@
 package com.wuest.from_the_depths.config;
 
-import java.util.ArrayList;
-
 import com.google.common.base.Strings;
 import com.wuest.from_the_depths.base.BaseConfig;
 import com.wuest.from_the_depths.entityinfo.BossAddInfo;
 import com.wuest.from_the_depths.entityinfo.SpawnInfo;
-
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.math.BlockPos;
+
+import java.util.ArrayList;
 
 /**
  * This is the configuration class for the drafter tile entity. This is what
@@ -87,7 +86,7 @@ public class ConfigTileEntityAltarOfSpawning extends BaseConfig {
 
         NBTTagList preBossMinionTagList = tag.getTagList("preBossMinions", 10);
 
-        if (!preBossMinionTagList.hasNoTags()) {
+        if (!preBossMinionTagList.isEmpty()) {
           for (int i = 0; i < preBossMinionTagList.tagCount(); i++) {
             NBTTagCompound bossAddInfoCompound = preBossMinionTagList.getCompoundTagAt(i);
             BossAddInfo bossAddInfo = new BossAddInfo();

--- a/src/main/java/com/wuest/from_the_depths/config/ModConfiguration.java
+++ b/src/main/java/com/wuest/from_the_depths/config/ModConfiguration.java
@@ -1,13 +1,12 @@
 package com.wuest.from_the_depths.config;
 
-import java.util.HashMap;
-import java.util.Map.Entry;
-
 import com.wuest.from_the_depths.FromTheDepths;
 import com.wuest.from_the_depths.proxy.CommonProxy;
-
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.config.Configuration;
+
+import java.util.HashMap;
+import java.util.Map.Entry;
 
 /**
  * This class is used to hold the mod configuration.
@@ -25,6 +24,7 @@ public class ModConfiguration {
 	private static String altarSpawningHeightName = "Altar Spawning Height";
 	private static String showAltarSpawningTextName = "Show Altar Spawning Text";
 	private static String enableArenaStyleRestrictionsName = "Enable Arena Style Restrictions";
+	private static String canSpawnMultipleBossesName = "Allow Spawning of multiple bosses";
 
 	// Configuration Options.
 	public boolean allowAltarToBeDestroyed;
@@ -32,6 +32,7 @@ public class ModConfiguration {
 	public int altarSpawningHeight;
 	public boolean showAltarSpawningText;
 	public boolean enableArenaStyleRestrictions;
+	public boolean canSpawnMultipleBosses;
 
 	public HashMap<String, Boolean> recipeConfiguration;
 
@@ -41,7 +42,7 @@ public class ModConfiguration {
 	public static String[] recipeKeys = new String[]{arenaStructureKey,};
 
 	public ModConfiguration() {
-		this.recipeConfiguration = new HashMap<String, Boolean>();
+		this.recipeConfiguration = new HashMap<>();
 	}
 
 	public static void syncConfig() {
@@ -73,6 +74,11 @@ public class ModConfiguration {
 				ModConfiguration.enableArenaStyleRestrictionsName, ModConfiguration.OPTIONS, true,
 				"Determines if the area around the altar needs to be solid and flat. server configuration overrides client.");
 
+		CommonProxy.proxyConfiguration.canSpawnMultipleBosses = config.getBoolean(
+				ModConfiguration.canSpawnMultipleBossesName, ModConfiguration.OPTIONS, true,
+				"Specifies whether a player can summon multiple bosses at the same time"
+		);
+
 		// Recipe configuration.
 		for (String key : ModConfiguration.recipeKeys) {
 			boolean value = config.getBoolean(key, RecipeOptions, true,
@@ -92,6 +98,7 @@ public class ModConfiguration {
 		tag.setInteger(ModConfiguration.altarSpawningRadiusName, this.altarSpawningRadius);
 		tag.setInteger(ModConfiguration.altarSpawningHeightName, this.altarSpawningHeight);
 		tag.setBoolean(ModConfiguration.showAltarSpawningTextName, this.showAltarSpawningText);
+		tag.setBoolean(ModConfiguration.canSpawnMultipleBossesName, this.canSpawnMultipleBosses);
 
 		for (Entry<String, Boolean> entry : this.recipeConfiguration.entrySet()) {
 			tag.setBoolean(entry.getKey(), entry.getValue());
@@ -107,6 +114,7 @@ public class ModConfiguration {
 		config.altarSpawningHeight = tag.getInteger(ModConfiguration.altarSpawningHeightName);
 		config.altarSpawningRadius = tag.getInteger(ModConfiguration.altarSpawningRadiusName);
 		config.showAltarSpawningText = tag.getBoolean(ModConfiguration.showAltarSpawningTextName);
+		config.canSpawnMultipleBosses = tag.getBoolean(ModConfiguration.canSpawnMultipleBossesName);
 
 		for (String key : ModConfiguration.recipeKeys) {
 			config.recipeConfiguration.put(key, tag.getBoolean(key));

--- a/src/main/java/com/wuest/from_the_depths/entityinfo/BaseMonster.java
+++ b/src/main/java/com/wuest/from_the_depths/entityinfo/BaseMonster.java
@@ -118,7 +118,7 @@ public abstract class BaseMonster {
 						FromTheDepths.logger.error(exception);
 					}
 
-					if (compound != null && !compound.hasNoTags()) {
+					if (compound != null && !compound.isEmpty()) {
 						for (String tagKey : compound.getKeySet()) {
 							serializedEntity.setTag(tagKey, compound.getTag(tagKey));
 						}
@@ -306,7 +306,7 @@ public abstract class BaseMonster {
 
 			NBTTagList dropList = tag.getTagList("additionalDrops", 10);
 
-			if (!dropList.hasNoTags()) {
+			if (!dropList.isEmpty()) {
 				for (int i = 0; i < dropList.tagCount(); i++) {
 					NBTTagCompound dropInfoTag = dropList.getCompoundTagAt(i);
 					DropInfo dropInfo = new DropInfo();

--- a/src/main/java/com/wuest/from_the_depths/entityinfo/BossAddInfo.java
+++ b/src/main/java/com/wuest/from_the_depths/entityinfo/BossAddInfo.java
@@ -10,6 +10,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
 
+import java.util.List;
+
 public class BossAddInfo extends BaseMonster implements INBTSerializable<BossAddInfo> {
 	public int minSpawns;
 	public int maxSpawns;
@@ -72,18 +74,20 @@ public class BossAddInfo extends BaseMonster implements INBTSerializable<BossAdd
 	 *
 	 * @return True when this minion is done spawning; otherwise false.
 	 */
-	public boolean processMinionSpawning(World world, BlockPos pos, ICommandSender commandSender) {
+	public boolean processMinionSpawning(World world, BlockPos pos, ICommandSender commandSender, List<Integer> entities) {
 		this.spawning = true;
 
 		if (this.numberLeftToSpawn == 0 && this.nextWaveOfAdds != null) {
 			// This minion is done spawning but there is another wave, process that now.
-			return this.nextWaveOfAdds.processMinionSpawning(world, pos, commandSender);
+			return this.nextWaveOfAdds.processMinionSpawning(world, pos, commandSender, entities);
 		} else if (this.numberLeftToSpawn == 0) {
 			// Spawning is complete and there are no more waves to process.
 			return true;
 		} else if (this.timeUntilNextSpawn <= 0) {
 			// There is something to spawn and we reached the timer; do that now.
 			Entity entity = this.createEntityForWorld(world, pos.up(), commandSender);
+			entities.add(entity.getEntityId());
+			//System.out.println("added " + entity.getDisplayName().getFormattedText() + " to the list");
 
 			if (entity == null) {
 				TextComponentString component = new TextComponentString(

--- a/src/main/java/com/wuest/from_the_depths/entityinfo/DropInfo.java
+++ b/src/main/java/com/wuest/from_the_depths/entityinfo/DropInfo.java
@@ -3,7 +3,6 @@ package com.wuest.from_the_depths.entityinfo;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.wuest.from_the_depths.FromTheDepths;
-
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -132,7 +131,7 @@ public class DropInfo implements INBTSerializable<DropInfo> {
 							FromTheDepths.logger.error(exception);
 						}
 
-						if (compound != null && !compound.hasNoTags()) {
+						if (compound != null && !compound.isEmpty()) {
 						  stack.setTagCompound(compound);
 						}
 					}

--- a/src/main/java/com/wuest/from_the_depths/entityinfo/SpawnInfo.java
+++ b/src/main/java/com/wuest/from_the_depths/entityinfo/SpawnInfo.java
@@ -1,9 +1,9 @@
 package com.wuest.from_the_depths.entityinfo;
 
-import java.util.ArrayList;
-
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+
+import java.util.ArrayList;
 
 public class SpawnInfo implements INBTSerializable<SpawnInfo> {
   public String key;
@@ -85,7 +85,7 @@ public class SpawnInfo implements INBTSerializable<SpawnInfo> {
 
       spawnInfo.bossAddInfo = new ArrayList<>();
 
-      if (!bossAddInfo.hasNoTags()) {
+      if (!bossAddInfo.isEmpty()) {
         for (int i = 0; i < bossAddInfo.tagCount(); i++) {
           NBTTagCompound addInfoTag = bossAddInfo.getCompoundTagAt(i);
           BossAddInfo addInfo = new BossAddInfo();

--- a/src/main/java/com/wuest/from_the_depths/entityinfo/restrictions/RestrictionBundle.java
+++ b/src/main/java/com/wuest/from_the_depths/entityinfo/restrictions/RestrictionBundle.java
@@ -68,7 +68,7 @@ public class RestrictionBundle {
         if (canStart && biomes != null) {
             canStart = SpawnRestrictions.BIOME.test(new Tuple<>(pos, world), biomes);
             if (!canStart) {
-                String biomesString = Arrays.stream(biomes).map(resLoc -> resLoc.getResourcePath().replace("_", "")).reduce("", (s, s2) -> s + ", " + s2);
+                String biomesString = Arrays.stream(biomes).map(resLoc -> resLoc.getPath().replace("_", "")).reduce("", (s, s2) -> s + ", " + s2);
                 message = new TextComponentTranslation("from_the_depths.restrictions.biomes", biomesString);
             }
         }

--- a/src/main/java/com/wuest/from_the_depths/entityinfo/restrictions/RestrictionBundle.java
+++ b/src/main/java/com/wuest/from_the_depths/entityinfo/restrictions/RestrictionBundle.java
@@ -1,14 +1,22 @@
 package com.wuest.from_the_depths.entityinfo.restrictions;
 
 import com.wuest.from_the_depths.base.Weather;
+import com.wuest.from_the_depths.integration.SSHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Arrays;
 
+/**
+ * Bundles all restriction types together (excluding Serene Season restrictions that are tested in {@link SSHelper#testSeasonRestrictions(String, World)})
+ * @author Davoleo
+ * @implNote Fields are not final because I don't know if GSON can serialize them correctly if they are :P
+ */
+@SuppressWarnings("FieldMayBeFinal")
 public class RestrictionBundle {
 
     private Integer[] dimensions;
@@ -32,7 +40,7 @@ public class RestrictionBundle {
         groundRadius = 0;
     }
 
-    public Tuple<Boolean, TextComponentTranslation> testAll(World world, BlockPos pos) {
+    public Pair<Boolean, TextComponentTranslation> testAll(String spawnKey, World world, BlockPos pos) {
         boolean canStart = true;
         TextComponentTranslation message = null;
 
@@ -86,7 +94,15 @@ public class RestrictionBundle {
                 message = new TextComponentTranslation("from_the_depths.restrictions.ground_radius", groundRadius);
         }
 
-        return new Tuple<>(canStart, message);
+        if (canStart) {
+            Pair<Boolean, String> resultAndCorrectSeason = SSHelper.testSeasonRestrictions(spawnKey, world);
+            canStart = resultAndCorrectSeason.getLeft();
+            String correctSeason = resultAndCorrectSeason.getRight();
+            if (!canStart)
+                message = new TextComponentTranslation("from_the_depths.restrictions.season", correctSeason);
+        }
+
+        return Pair.of(canStart, message);
     }
 
     @Override

--- a/src/main/java/com/wuest/from_the_depths/events/ClientEventHandler.java
+++ b/src/main/java/com/wuest/from_the_depths/events/ClientEventHandler.java
@@ -3,7 +3,6 @@ package com.wuest.from_the_depths.events;
 import com.wuest.from_the_depths.FromTheDepths;
 import com.wuest.from_the_depths.ModRegistry;
 import com.wuest.from_the_depths.proxy.ClientProxy;
-
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
@@ -113,7 +112,7 @@ public class ClientEventHandler {
    * @param item The item to register.
    */
   public static void regItem(Item item) {
-    ClientEventHandler.regItem(item, 0, item.getUnlocalizedName().substring(5));
+    ClientEventHandler.regItem(item, 0, item.getTranslationKey().substring(5));
   }
 
   /**

--- a/src/main/java/com/wuest/from_the_depths/events/ModEventHandler.java
+++ b/src/main/java/com/wuest/from_the_depths/events/ModEventHandler.java
@@ -8,7 +8,6 @@ import com.wuest.from_the_depths.entityinfo.DropInfo;
 import com.wuest.from_the_depths.proxy.ClientProxy;
 import com.wuest.from_the_depths.proxy.CommonProxy;
 import com.wuest.from_the_depths.proxy.messages.ConfigSyncMessage;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
@@ -91,7 +90,7 @@ public class ModEventHandler {
         if (trackingTag.hasKey("additionalDrops")) {
           NBTTagList additionalDropList = trackingTag.getTagList("additionalDrops", 10);
 
-          if (!additionalDropList.hasNoTags()) {
+          if (!additionalDropList.isEmpty()) {
             for (int i = 0; i < additionalDropList.tagCount(); i++) {
               NBTTagCompound dropInfoTag = additionalDropList.getCompoundTagAt(i);
               DropInfo dropInfo = new DropInfo();

--- a/src/main/java/com/wuest/from_the_depths/gui/GuiLangKeys.java
+++ b/src/main/java/com/wuest/from_the_depths/gui/GuiLangKeys.java
@@ -1,14 +1,14 @@
 package com.wuest.from_the_depths.gui;
 
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.EnumDyeColor;
+import net.minecraft.util.EnumFacing;
+
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Field;
-
-import net.minecraft.client.resources.I18n;
-import net.minecraft.item.EnumDyeColor;
-import net.minecraft.util.EnumFacing;
 
 /**
  * This class contains the keys for the language files.
@@ -188,7 +188,7 @@ public class GuiLangKeys
 	
 	public static String translateDye(EnumDyeColor dyeColor)
 	{
-		return GuiLangKeys.translateString("from_the_depths.gui." + dyeColor.getUnlocalizedName());
+		return GuiLangKeys.translateString("from_the_depths.gui." + dyeColor.getTranslationKey());
 	}
 	
 	/**

--- a/src/main/java/com/wuest/from_the_depths/integration/SSHelper.java
+++ b/src/main/java/com/wuest/from_the_depths/integration/SSHelper.java
@@ -1,0 +1,97 @@
+package com.wuest.from_the_depths.integration;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import net.minecraft.util.JsonUtils;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Loader;
+import org.apache.commons.lang3.tuple.Pair;
+import sereneseasons.api.season.ISeasonState;
+import sereneseasons.api.season.Season;
+import sereneseasons.api.season.SeasonHelper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Helper class that contains Utility Methods to interact with Serene Seasons.
+ * (trying to keep the mod as an Optional Soft Dependency)
+ * @author Davoleo
+ */
+public class SSHelper {
+
+    public static final BooleanSupplier isSereneSeasonLoaded = () -> Loader.isModLoaded("sereneseasons");
+    public static Map<String, Pair<Season, Season.SubSeason>> seasonRestrictions = new HashMap<>();
+
+    private static final BiPredicate<Pair<Season, Season.SubSeason>, World> SEASON_SPAWN_RESTRICTION = (season, world) -> {
+        ISeasonState worldSeason = SeasonHelper.getSeasonState(world);
+        if (season.getRight() == null)
+            return worldSeason.getSeason() == season.getLeft();
+        else
+            return worldSeason.getSeason() == season.getLeft() && worldSeason.getSubSeason() == season.getRight();
+    };
+
+    /**
+     * Parses {@link Season} and {@link sereneseasons.api.season.Season.SubSeason} objects from string parameters and returns a pair of them
+     * @param seasonStr Season string representation (should be the same name as {@link Season} constants)
+     * @param subSeasonStr SubSeason string representation (should be the same name as {@link sereneseasons.api.season.Season.SubSeason} constants)
+     * @throws IllegalArgumentException When any of the string representation of enum constants are wrong (the exception IS NOT handled here)
+     */
+    private static Pair<Season, Season.SubSeason> seasonFromStrings(String seasonStr, String subSeasonStr) throws IllegalArgumentException {
+
+        Season season = Season.valueOf(seasonStr);
+
+        Season.SubSeason subSeason = null;
+        if (!subSeasonStr.equals("")) {
+            subSeason = Season.SubSeason.valueOf(subSeasonStr + '_' + seasonStr);
+        }
+
+        return Pair.of(season, subSeason);
+    }
+
+    /**
+     * Adds a season restriction in the form of a Pair of seasons to the {@link SSHelper#seasonRestrictions} map
+     * @param spawnKey The boss key this season restriction is bound to.
+     * @param seasonObj The season restriction information (directly from the JSON)
+     * @throws JsonSyntaxException when the "season" attribute is not present
+     *      (Note that subSeason is optional and fallbacks to "" in case it's not given any value)
+     */
+    public static void addSeasonRestriction(String spawnKey, JsonObject seasonObj) throws JsonSyntaxException
+    {
+        String sString = JsonUtils.getString(seasonObj, "season");
+        String sSString = JsonUtils.getString(seasonObj, "subSeason", "");
+        Pair<Season, Season.SubSeason> seasons = seasonFromStrings(sString.toUpperCase(), sSString.toUpperCase());
+        seasonRestrictions.put(spawnKey, seasons);
+    }
+
+    /**
+     * @param world ZA WARUDO
+     * @return whether season restrictions are asserted for the passed boss spawn key.
+     */
+    public static Pair<Boolean, String> testSeasonRestrictions(String spawnKey, World world) {
+        //Return true if Serene Seasons is not installed
+        if (!isSereneSeasonLoaded.getAsBoolean())
+            return Pair.of(true, null);
+
+        Pair<Season, Season.SubSeason> seasonPair = seasonRestrictions.get(spawnKey);
+
+        //Return true if no season restrictions are specified
+        if (seasonPair == null)
+            return Pair.of(true, null);
+
+        String correctSeason;
+        //Save the correct
+        if (seasonPair.getRight() != null)
+            correctSeason = seasonPair.getRight().toString().replace('_', ' ').toLowerCase();
+        else
+            correctSeason = seasonPair.getLeft().toString().toLowerCase();
+
+        //Test the SEASON predicate
+        boolean result = SEASON_SPAWN_RESTRICTION.test(seasonRestrictions.get(spawnKey), world);
+
+        return Pair.of(result, correctSeason);
+    }
+
+}

--- a/src/main/java/com/wuest/from_the_depths/items/ItemTotemOfSpawning.java
+++ b/src/main/java/com/wuest/from_the_depths/items/ItemTotemOfSpawning.java
@@ -19,6 +19,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.EnumDifficulty;
 import net.minecraft.world.World;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
 
@@ -128,10 +129,12 @@ public class ItemTotemOfSpawning extends Item {
 
 						if (spawnInfo != null) {
 							RestrictionBundle restrictionBundle = ModRegistry.spawnRestrictions.get(spawnInfo.key);
-							Tuple<Boolean, TextComponentTranslation> testResults = restrictionBundle.testAll(worldIn, pos);
-							if (!testResults.getFirst()) {
-								player.sendMessage(testResults.getSecond());
-								return EnumActionResult.FAIL;
+							if (restrictionBundle != null) {
+								Pair<Boolean, TextComponentTranslation> testResults = restrictionBundle.testAll(spawnInfo.key, worldIn, pos);
+								if (!testResults.getLeft()) {
+									player.sendMessage(testResults.getRight());
+									return EnumActionResult.FAIL;
+								}
 							}
 
 							if (spawnInfo.bossInfo.isValidEntity(worldIn)) {

--- a/src/main/java/com/wuest/from_the_depths/items/ItemTotemOfSpawning.java
+++ b/src/main/java/com/wuest/from_the_depths/items/ItemTotemOfSpawning.java
@@ -43,7 +43,7 @@ public class ItemTotemOfSpawning extends Item {
 			ModRegistry.setItemName(this, name);
 		}
 
-		this.setUnlocalizedName("from_the_depths:" + name);
+		this.setTranslationKey("from_the_depths:" + name);
 	}
 
 	/**
@@ -56,7 +56,7 @@ public class ItemTotemOfSpawning extends Item {
 	 */
 	@Override
 	public NBTTagCompound getNBTShareTag(ItemStack stack) {
-		if (stack.getTagCompound() == null || stack.getTagCompound().hasNoTags()) {
+		if (stack.getTagCompound() == null || stack.getTagCompound().isEmpty()) {
 			// Make sure to serialize the NBT for this stack so the information is pushed to
 			// the client and the appropriate Icon is displayed for this stack.
 			stack.setTagCompound(stack.serializeNBT());
@@ -71,10 +71,10 @@ public class ItemTotemOfSpawning extends Item {
 		SpawnInfo spawnInfo = this.getSpawnInfoFromItemStack(stack);
 
 		if (spawnInfo != null) {
-			return Utilities.localize(stack.getUnlocalizedName()).trim() + " (" + spawnInfo.key + ")";
+			return Utilities.localize(stack.getTranslationKey()).trim() + " (" + spawnInfo.key + ")";
 		}
 
-		return Utilities.localize(stack.getUnlocalizedName()).trim() + " (" + Utilities.localize("from_the_depths.messages.no_boss") + ")";
+		return Utilities.localize(stack.getTranslationKey()).trim() + " (" + Utilities.localize("from_the_depths.messages.no_boss") + ")";
 	}
 
 	/**

--- a/src/main/resources/assets/from_the_depths/lang/en_us.lang
+++ b/src/main/resources/assets/from_the_depths/lang/en_us.lang
@@ -69,3 +69,4 @@ from_the_depths.restrictions.y_level_lower=The boss can only be spawned deeper u
 from_the_depths.restrictions.y_level_higher=The boss can only be spawned higher than a Y level of %d.
 from_the_depths.restrictions.y_level_equals=The boss can only be at the exact height of %d.
 from_the_depths.restrictions.ground_radius=This boss needs a flat ground area of %d blocks radius.
+from_the_depths.restrictions.season=This boss can only be spawned during %s season.

--- a/src/main/resources/assets/from_the_depths/lang/en_us.lang
+++ b/src/main/resources/assets/from_the_depths/lang/en_us.lang
@@ -55,7 +55,7 @@ from_the_depths.gui.black=Black
 # --- RoTN Edition BEGIN --- #
 # Misc Chat Status Messages
 from_the_depths.messages.no_boss=No Boss. Doesn't do anything.
-from_the_depths.messages.early_summon=Cannot spawn a monster now as additional monsters are going to be spawned. Please wait for all minions to be spawned.
+from_the_depths.messages.early_summon=Cannot spawn a monster now, try again later.
 from_the_depths.messages.invalid_arena=Cannot summon monster. The area around the altar must only be air in a square radius of %d blocks and height of %d blocks
 from_the_depths.messages.invalid_arena_ground=Cannot summon monster. The ground around the altar must be solid blocks in a square radius of %d blocks
 from_the_depths.messages.boss_entity_not_found=Can't Find Boss Entity with name '%s' in mod '%s'


### PR DESCRIPTION
It's a smaller one today, but contains multiple features :P

This PR's Content: 
- Mappings update: from `snapshot_20171003` to `snapshot_20180814`
  - Was getting some error due to Serene Seasons having more recent mappings and in the end the former ones were old af
- Serene Seasons Boss spawning restriction
  - you can specify season as well as an optional subseason during which the summoning can take place
- Global configuration option to block players from being able to spawn a boss right away before killing the old one