### PR TITLE
Boss Spawning Messages

### DIFF
--- a/src/main/java/com/wuest/from_the_depths/entityinfo/BossAddInfo.java
+++ b/src/main/java/com/wuest/from_the_depths/entityinfo/BossAddInfo.java
@@ -1,11 +1,12 @@
 package com.wuest.from_the_depths.entityinfo;
 
+import com.google.common.base.Predicates;
 import com.wuest.from_the_depths.FromTheDepths;
-import com.wuest.from_the_depths.tileentity.TileEntityAltarOfSpawning;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EntitySelectors;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
@@ -85,7 +86,7 @@ public class BossAddInfo extends BaseMonster implements INBTSerializable<BossAdd
 			return true;
 		} else if (this.timeUntilNextSpawn <= 0) {
 			// There is something to spawn and we reached the timer; do that now.
-			Entity entity = this.createEntityForWorld(world, pos.up(), commandSender);
+			Entity entity = this.createEntityForWorld(world, pos.up(), null, commandSender);
 			entities.add(entity.getEntityId());
 			//System.out.println("added " + entity.getDisplayName().getFormattedText() + " to the list");
 
@@ -93,7 +94,8 @@ public class BossAddInfo extends BaseMonster implements INBTSerializable<BossAdd
 				TextComponentString component = new TextComponentString(
 						"Unable to summon additional monster due to limited air space in summoning area");
 
-				for (EntityPlayerMP player : world.getPlayers(EntityPlayerMP.class, TileEntityAltarOfSpawning.VALID_PLAYER)) {
+				for (EntityPlayerMP player : world.getPlayers(EntityPlayerMP.class,
+						Predicates.and(EntitySelectors.IS_ALIVE, EntitySelectors.withinRange(pos.getX(), pos.getY(), pos.getZ(), 15)))) {
 					player.sendMessage(component);
 				}
 			}

--- a/src/main/java/com/wuest/from_the_depths/entityinfo/BossInfo.java
+++ b/src/main/java/com/wuest/from_the_depths/entityinfo/BossInfo.java
@@ -33,6 +33,8 @@ public class BossInfo extends BaseMonster implements INBTSerializable<BossInfo> 
     newInstance.nbt = this.nbt;
     newInstance.spawnEffect = this.spawnEffect;
     newInstance.shouldSpawnInAir = this.shouldSpawnInAir;
+    newInstance.warningMessage = this.warningMessage;
+    newInstance.spawnedMessage = this.spawnedMessage;
 
     for (DropInfo info : this.additionalDrops) {
       newInstance.additionalDrops.add(info.clone());

--- a/src/main/java/com/wuest/from_the_depths/entityinfo/restrictions/SpawnRestrictions.java
+++ b/src/main/java/com/wuest/from_the_depths/entityinfo/restrictions/SpawnRestrictions.java
@@ -1,9 +1,5 @@
 package com.wuest.from_the_depths.entityinfo.restrictions;
 
-import com.google.gson.TypeAdapter;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
-import com.google.gson.stream.JsonWriter;
 import com.wuest.from_the_depths.Utilities;
 import com.wuest.from_the_depths.base.Weather;
 import net.minecraft.util.ResourceLocation;
@@ -13,7 +9,6 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import org.apache.commons.lang3.ArrayUtils;
 
-import java.io.IOException;
 import java.util.function.BiPredicate;
 
 /**


### PR DESCRIPTION
This PR's Content:
- Warning Message as soon as the totem is used on the altar
- Boss Spawning Message when the boss entity is actually spawned

Note: Both Messages can be formatted through usual vanilla formatting codes (e.g. `§c`)

and are specified in the bossInfo Object of the json config in this way:
```json
    "warningMessage": "§n§fyou feel like you're going to have a §cbad §ftime",
    "spawnedMessage": "§fThe Spoopy Scary Skeleton has been §ksummoned",
```

Ready to merge 👌 @democat3457 